### PR TITLE
fix max_symbol_count usage

### DIFF
--- a/LCD_1602_RUS_ALL.h
+++ b/LCD_1602_RUS_ALL.h
@@ -265,7 +265,7 @@ class LCD_1602_RUS : public LCD_LIB {
         //Запомианем, что букве соответствует определенный индекс
         *index = symbol_index;
         symbol_index++;
-        if (symbol_index > max_symbol_count)
+        if (symbol_index >= max_symbol_count)
         {
           ResetAllIndex();
         }


### PR DESCRIPTION
symbol_index может иметь значение равное max_symbol_count, что превышает допустимое значение

Пример для воспроизведения ошибки:
```c++
#define _LCD_TYPE 2
#include "LCD_1602_RUS_ALL.h"

#define P_DISPLAY_RS 32
#define P_DISPLAY_EN 33
#define P_DISPLAY_D4 23
#define P_DISPLAY_D5 22
#define P_DISPLAY_D6 19
#define P_DISPLAY_D7 18

LCD_1602_RUS lcd{P_DISPLAY_RS, P_DISPLAY_EN, P_DISPLAY_D4, P_DISPLAY_D5, P_DISPLAY_D6, P_DISPLAY_D7};

void setup(){
  lcd.begin(16, 2);
}

void loop() {
    lcd.setCursor(0, 0);
    lcd.print("абвгдежз");
    delay(5000);
    lcd.setCursor(0, 0);
    lcd.print("ийклмноп");
    delay(5000);
    lcd.setCursor(0, 0);
    lcd.print("рстуфхцч");
    delay(5000);
    lcd.setCursor(0, 0);
    lcd.print("шщъыьэюя");
    delay(5000);
}
```
