### PR TITLE
Fixed Unicode character presence check

### DIFF
--- a/LCD_1602_RUS_ALL.h
+++ b/LCD_1602_RUS_ALL.h
@@ -277,7 +277,7 @@ class LCD_1602_RUS : public LCD_LIB {
     void printwc(const wchar_t _chr) {
       uint8_t rus_[8];
 
-      if (_chr < 128) //Английский алфавит без изменения
+      if (_chr < 256) //Английский алфавит без изменения
         LCD_LIB::print((char)_chr);
       else
         //Кириллица


### PR DESCRIPTION
The check for numbers less than _128_ is valid when we are dealing with single-byte values. However, a variable of type **wchar_t** is two bytes long, so Cyrillic characters will start somewhere from the number _1000_ and above. Therefore, all values from _0_ to _255_ represent Latin characters, while starting from _265_, they are already two-byte utf8 characters. If you accidentally truncate a string with Arduino's built-in libraries, a number higher than _128_ may end up in the check, leading to a microcontroller reboot. Here's a minimal example:

```
String newstring = "Д";
newstring.remove(1);
lcd.print(newstring);
String newstring2 = "АБВГД";
newstring2.remove(3);
lcd.print(newstring2);
```

This fix allows truncated characters to be displayed properly without causing errors.